### PR TITLE
remove `x86_64-darwin`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,5 @@
 [
   "aarch64-darwin"
   "aarch64-linux"
-  "x86_64-darwin"
   "x86_64-linux"
 ]


### PR DESCRIPTION
nixpkgs `26.05` will be final release to support `x86_64-darwin`. Releases 26.11 onwards will not support the system. However, many people are still relying on this architecture. Unitl then, please consider creating a `future-26.11` branch or similar (I can't propose PRing to a new branch)

Tackles nix-system/default#1, nix-systems/nix-systems#17